### PR TITLE
Update Perception-Driven Manipulation Demo

### DIFF
--- a/gh_pages/_source/demo1/Inspect-the-package.md
+++ b/gh_pages/_source/demo1/Inspect-the-package.md
@@ -9,13 +9,6 @@ source /opt/ros/kinetic/setup.bash
 catkin init
 ```
 
-## Download source dependencies
->Use the [wstool](http://wiki.ros.org/wstool) command to download the repositories listed in the `src/.rosinstall` file
-```
-cd ~/perception_driven_ws/src/
-wstool update
-```
-
 ## Download debian dependencies
 >Make sure you have installed and configured the [rosdep tool](http://wiki.ros.org/rosdep).
 >Then, run the following command from the `src` directory of your workspace.


### PR DESCRIPTION
Removed "Download Source Dependencies" section from documentation. (.rosinstall was removed because all packages are now available from apt.)